### PR TITLE
Add a dns-persist validation method for IPs

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1146,21 +1146,13 @@ CAs performing validations using this method MUST implement Multi-Perspective Is
 
 ##### 3.2.2.5.8 DNS TXT Record with Persistent Value in the Reverse Namespace
 
-Confirming the Applicant's control over an IP address by confirming the presence of a persistent record identifying the Applicant in a DNS TXT record for an Authorization Domain Name that consists of the reverse zone base domain of the IP address (as defined in RFC 1035 and RFC 3596) that is prefixed with one DNS TXT Record Persistent DCV Domain Label.
+Confirming the Applicant's control over an IP address by 
 
-The CA MUST confirm the presence of a TXT record whose RDATA value fulfills the following requirements:
+1. Constructing an Authorization Domain Name that consists of the reverse zone base domain of the IP address (as defined in RFC 1035 and RFC 3596) and prefixing it with one DNS TXT Record Persistent DCV Domain Label (e.g. _validation-persist.1.2.3.4.in-addr.arpa), and
 
-1. The RDATA value MUST conform to the `issue-value` syntax as defined in RFC 8659, section 4.2; and
-2. The `issuer-domain-name` value MUST be an Issuer Domain Name disclosed by the CA in Section 4.2 of the CA's Certificate Policy and/or Certification Practices Statement; and
-3. The `issue-value` MUST contain an `accounturi` parameter, where the parameter value is a unique URI (as described by RFC 8657, Section 3) identifying the account of the Applicant which requested validation for this IP address; and
-4. The `issue-value` MAY contain a `persistUntil` parameter. If present, the parameter value MUST be a base-10 encoded integer representing a UNIX timestamp (the number of seconds since 1970-01-01T00:00:00Z ignoring leap seconds). CAs MUST interpret the `persistUntil` parameter as defined in [Section 3.2.2.4.22](#322422-dns-txt-record-with-persistent-value).
-5. The `issue-value` MAY contain additional parameters. CAs MUST ignore any unknown parameter keys.
+2. Verifying control over the Authorization Domain Name as defined in [Section 3.2.2.4.22](#322422-dns-txt-record-with-persistent-value).
 
 The CA MUST NOT follow CNAME or DNAME aliases when resolving the TXT record at the Authorization Domain Name; the TXT record to be validated MUST be located at that exact label.
-
-CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same challenge information as the Primary Network Perspective.
-
-If the DNS TXT record has a TTL less than the validation data reuse period (see [Section 4.2.1](#421-performing-identification-and-authentication-functions)), then the CA MUST consider the validation data reuse period to be equal to the TTL or 8 hours, whichever is greater.
 
 #### 3.2.2.6 Wildcard Domain Validation
 


### PR DESCRIPTION
## Overview
Section 3.2.2.5.8 introduces a new domain control validation method to prove control over an IP address listed in the Subject/SAN of a certificate. The method is an extension of the “dns-persist” method, where the applicant’s CA of choice and account URI is listed in a TXT record at the persistent DCV domain label in the IP address’s reverse zone. 
The applicant places an authorized CA along with its account URI in a TXT record under the validation label subdomain of the IP address’s reverse zone, thus granting the CA permission to issue for the IP address.

### Example DNS TXT record: 
_validation-persist[.1.2.3.4.in-addr.arpa](about:blank) IN TXT “ca.example; accounturi=https://ca.example/acct/123”

### Specification
1. The validation domain name is constructed by prepending the persistent DCV domain label “_validation-persist” to the applicant IP address’s reverse base domain name (as specified per RFC1035/RFC3596).
2. The applicant must provision a TXT record at the constructed validation domain name containing the CA authorized to issue and the Applicant’s Account URI at this CA.
3. The CA must query the constructed validation domain name and verify that the returned RRset contains at least one TXT record with the expected value. 
4. CAs must not follow CNAME or DNAME aliases for this method, avoiding any crossover risks introduced by querying a different base domain for the persistent DCV record. If needed, delegation of the validation domain name can be achieved by the reverse zone owner (e.g., ISP) delegating the _ child zone via NS records to the holder of the IP address.
5. CAs performing validation using this method must apply multi-perspective issuance corroboration (3.2.2.9).

### Security Benefits
1. Eliminates “crossover” risk: requires demonstration of direct control over the IP address’s reverse zones, and removes the security vulnerabilities introduced by allowing methods defined in 3.2.2.4.8.
2. Reduces risks of PTR record staleness: this method requires that a validation-specific TXT record be provisioned under the IP address’s reverse zone, rather than a PTR record under the reverse zone (which are not validation-specific records and often infrequently updated). This eliminates the risk of outdated PTR records pointing to deprovisioned domains delegating the validation process to an unrelated resource.
3. Keeps a way to validate IP address certificates via DNS, useful for situations where opening additional ports (e.g., 80/443) for HTTP- or TLS-ALPN-based DCV methods introduces additional security risk for servers (e.g., ssh frontends), or requiring that an HTTP or TLS-ALPN challenge be consistently validated from any instance of an anycasted/globally replicated deployment is unfeasible.

Special thanks to @gcimaszewski for doing the necessary research to determine the feasibility of this approach and putting together this proposal.